### PR TITLE
Fix hard reset to 6 buttons per row after reload

### DIFF
--- a/MacroToolkit/modules/mainframe.lua
+++ b/MacroToolkit/modules/mainframe.lua
@@ -263,7 +263,7 @@ function MT:CreateMTFrame()
 
     local mtscrollchild = CreateFrame("Frame", "MacroToolkitButtonContainer", mtscroll, "BackdropTemplate")
     do
-        mtscrollchild:SetSize(285, 10)
+        mtscrollchild:SetSize(mtframe:GetWidth() - 345, 10)
         mtscrollchild:SetPoint("TOPLEFT")
         self:ContainerOnLoad(mtscrollchild)
         mtscroll:SetScrollChild(mtscrollchild)


### PR DESCRIPTION
After a reload/relog the frame always resets back to 6 buttons per row instead of how many buttons can fit. This is fixed by using the actual frame width when calculating the buttons per row on load instead of only when resizing.